### PR TITLE
-Changed diff calculations: Avg diff is now a 60 second rolling avera…

### DIFF
--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -111,6 +111,7 @@ uint32 World::m_currentDiffSum = 0;
 uint32 World::m_currentDiffSumIndex = 0;
 uint32 World::m_averageDiff = 0;
 uint32 World::m_maxDiff = 0;
+list<uint32> World::m_histDiff;
 
 /// World constructor
 World::World() : mail_timer(0), mail_timer_expires(0), m_NextDailyQuestReset(0), m_NextWeeklyQuestReset(0), m_NextMonthlyQuestReset(0), m_opcodeCounters(NUM_MSG_TYPES)
@@ -123,6 +124,7 @@ World::World() : mail_timer(0), mail_timer_expires(0), m_NextDailyQuestReset(0),
     m_startTime = m_gameTime;
     m_maxActiveSessionCount = 0;
     m_maxQueuedSessionCount = 0;
+    m_maxDiff = 0;
 
     m_defaultDbcLocale = DEFAULT_LOCALE;
     m_availableDbcLocaleMask = 0;
@@ -1831,14 +1833,31 @@ void World::Update(uint32 diff)
     m_currentDiff = diff;
     m_currentDiffSum += diff;
     m_currentDiffSumIndex++;
-    if (m_currentDiffSumIndex && m_currentDiffSumIndex % 600 == 0)
+
+    m_histDiff.push_back(diff);
+    m_maxDiff = std::max(m_maxDiff, diff);
+
+    while(m_histDiff.size() >= 600)
     {
-        m_averageDiff = (uint32)(m_currentDiffSum / m_currentDiffSumIndex);
-        if (m_maxDiff < m_averageDiff)
-            m_maxDiff = m_averageDiff;
-        sLog.outBasic("Avg Diff: %u. Sessions online: %u.", m_averageDiff, (uint32)GetActiveSessionCount());
-        sLog.outBasic("Max Diff (last 5 min): %u.", m_maxDiff);
+        m_currentDiffSum -= m_histDiff.front();
+        m_histDiff.pop_front();
     }
+
+    m_averageDiff = (uint32)(m_currentDiffSum / m_histDiff.size());
+
+    if (m_currentDiffSumIndex && m_currentDiffSumIndex % 60 == 0)
+    {
+       //m_averageDiff = (uint32)(m_currentDiffSum / m_currentDiffSumIndex);
+        //if (m_maxDiff < m_averageDiff)
+        //    m_maxDiff = m_averageDiff;
+        sLog.outBasic("Avg Diff: %u. Sessions online: %u.", m_averageDiff, (uint32)GetActiveSessionCount());
+        sLog.outBasic("Max Diff: %u.", m_maxDiff);
+    }
+    if (m_currentDiffSum % 3000 == 0)
+    {
+        m_maxDiff = *std::max_element(m_histDiff.begin(), m_histDiff.end());
+    }
+    /*
     if (m_currentDiffSum > 300000)
     {
         m_currentDiffSum = 0;
@@ -1864,7 +1883,8 @@ void World::Update(uint32 diff)
                 sLog.outBasic("Max Diff Increased: %u.", m_maxDiff);
             }
         }
-    }
+    }    
+    */
 
     ///- Update the different timers
     for (auto& m_timer : m_timers)

--- a/src/game/World/World.h
+++ b/src/game/World/World.h
@@ -1036,6 +1036,7 @@ class World
         static uint32 m_currentDiffSumIndex;
         static uint32 m_averageDiff;
         static uint32 m_maxDiff;
+        static std::list<uint32> m_histDiff;
 
         Messager<World> m_messager;
 


### PR DESCRIPTION
…ge that is calculated every tick. Max diff is now reset to the max diff of the last 60 seconds every 5 minutes.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
